### PR TITLE
Fix ignoring of YAML frontmatter

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "obsidian-sidekick",
   "name": "Sidekick",
   "description": "A companion to identify hidden connections that match your tags and pages",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "minAppVersion": "0.13.8",
   "author": "Hady Osman",
   "authorUrl": "https://hady.geek.nz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-sidekick",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A companion to identify hidden connections that match your tags and pages",
   "main": "src/index.ts",
   "repository": {

--- a/src/search/index.ts
+++ b/src/search/index.ts
@@ -37,7 +37,7 @@ export default class Search {
   private redactText(text: string): string {
     return text
       .replace(/```[\s\S]+?```/g, (m) => ' '.repeat(m.length)) // remove code blocks
-      .replace(/^\n+---[\s\S]+?---/g, (m) => ' '.repeat(m.length)) // remove yaml front matter
+      .replace(/^\n*?---[\s\S]+?---/g, (m) => ' '.repeat(m.length)) // remove yaml front matter
       .replace(/#+([a-zA-Z0-9_]+)/g, (m) => ' '.repeat(m.length)) // remove hashtags
       .replace(/\[(.*?)\]+/g, (m) => ' '.repeat(m.length)); // remove links
   }


### PR DESCRIPTION
Correctly handle the two valid frontmatter scenarios:

```
---
yaml: "with no empty lines preceding it"
---
```

and

```

---
yaml: "with empty lines preceding it"
---
```