### PR TITLE
fix: Escape + signs in search

### DIFF
--- a/src/cmExtension/suggestionsExtension.ts
+++ b/src/cmExtension/suggestionsExtension.ts
@@ -91,6 +91,9 @@ export const suggestionsExtension = (search: Search): ViewPlugin<PluginValue> =>
           const { positionStart, positionEnd, searchWord } = target.dataset;
 
           const replaceText = search.getSuggestionReplacement(searchWord);
+          if (!replaceText) {
+            return;
+          }
 
           const popup = new SuggestionsPopup();
           popup.show({

--- a/src/search/index.ts
+++ b/src/search/index.ts
@@ -1,5 +1,5 @@
 import { findAll } from 'highlight-words-core';
-import { Indexer } from '../indexing/indexer';
+import { Indexer } from '~/indexing/indexer';
 
 type SearchResult = {
   start: number;
@@ -11,13 +11,13 @@ export default class Search {
   constructor(private indexer: Indexer) {}
 
   public getSuggestionReplacement(text: string): string {
-    return this.indexer.index.find((index) => index.index === text.toLowerCase()).displayText;
+    return this.indexer.index.find((index) => index.index.replace(/\+/g, "\\+") === text.toLowerCase())?.displayText;
   }
 
   public find(text: string): SearchResult[] {
     const searchWords = this.indexer.index.map((index) => {
       try {
-        return index.index;
+        return index.index.replace(/\+/g, "\\+");
       } catch (err) {
         console.error('Cannot return text value of index', index, err);
       }


### PR DESCRIPTION
This fixes the crashes when creating the highlights, when some names include a + character. You might prefer to do this replacement in the index instead of in the search, I'm not sure.

I also added a failsafe in the getSuggestionReplacement. I have many wrong highlights in my file that crash on this statement because it cannot find the corresponding string in the index.