### PR TITLE
Gracefully degrade and warn if bad index

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "obsidian-sidekick",
   "name": "Sidekick",
   "description": "A companion to identify hidden connections that match your tags and pages",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "minAppVersion": "0.13.8",
   "author": "Hady Osman",
   "authorUrl": "https://hady.geek.nz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-sidekick",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A companion to identify hidden connections that match your tags and pages",
   "main": "src/index.ts",
   "repository": {

--- a/src/search/index.ts
+++ b/src/search/index.ts
@@ -45,8 +45,9 @@ export default class Search {
     const indexHits = results[0].matchData.metadata;
 
     return Object.keys(indexHits)
-      .reduce((acc: SearchResult[], indexHit: string) => {
-        const positions = indexHits[indexHit][DocumentKey].position;
+      .filter((indexHit) => this.existsInIndex(indexHit, indices))
+      .reduce((acc: SearchResult[], indexHit) => {
+        const positions: number[][] = indexHits[indexHit][DocumentKey].position;
 
         const searchResults = positions.map(
           (position): SearchResult => ({
@@ -60,6 +61,19 @@ export default class Search {
         return acc;
       }, [])
       .sort((a, b) => a.start - b.start); // Must sort by start position to prepare for highlighting
+  }
+
+  private existsInIndex(index: string, indices: Index): boolean {
+    const exists = indices[index] != null;
+
+    if (!exists) {
+      console.warn(
+        `Search hit "${index}" was not found in Obsidian index. This could be a bug. Report on https://github.com/hadynz/obsidian-sidekick/issues`,
+        indices
+      );
+    }
+
+    return exists;
   }
 
   private redactText(text: string): string {


### PR DESCRIPTION
This should be an unlikely situation, but it seems to be happening. A keyword that is being used for search, is not found in the list of keyword indices. This could be because of stemming?

So the plugin continues working for user, this change will skip such indices. It will also print to the console as a warning to help with debugging why this is taking place.