### PR TITLE
Use Aho-Corasick algorithm for searching

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "obsidian-sidekick",
   "name": "Sidekick",
   "description": "A companion to identify hidden connections that match your tags and pages",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "minAppVersion": "0.13.8",
   "author": "Hady Osman",
   "authorUrl": "https://hady.geek.nz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-sidekick",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "A companion to identify hidden connections that match your tags and pages",
   "main": "src/index.ts",
   "repository": {
@@ -35,7 +35,6 @@
     "@types/faker": "^5.5.8",
     "@types/jest": "^26.0.22",
     "@types/lodash": "^4.14.178",
-    "@types/lunr": "^2.3.4",
     "@types/webpack": "^5.28.0",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
@@ -69,8 +68,8 @@
     "*.{js,css,md}": "prettier --write"
   },
   "dependencies": {
+    "@tanishiking/aho-corasick": "^0.0.1",
     "lodash": "^4.17.21",
-    "lunr": "^2.3.9",
     "tippy.js": "^6.3.7"
   }
 }

--- a/src/indexing/indexModels.ts
+++ b/src/indexing/indexModels.ts
@@ -1,45 +1,36 @@
 import { TFile } from 'obsidian';
 
-import { stemmer } from '../utils/stemmer';
-
 export interface SearchIndex {
   replaceText: string;
   originalText: string;
-  stem: string;
 }
 
 export class TagIndex implements SearchIndex {
   public readonly originalText: string;
   public readonly replaceText: string;
-  public readonly stem: string;
 
   constructor(tag: string) {
     this.originalText = tag.replace(/#/, '');
     this.replaceText = tag;
-    this.stem = stemmer(this.originalText);
   }
 }
 
 export class AliasIndex implements SearchIndex {
   public readonly originalText: string;
   public readonly replaceText: string;
-  public readonly stem: string;
 
   constructor(file: TFile, word: string) {
     this.originalText = word;
     this.replaceText = `[[${file.basename}|${word}]]`;
-    this.stem = stemmer(this.originalText);
   }
 }
 
 export class PageIndex implements SearchIndex {
   public readonly originalText: string;
   public readonly replaceText: string;
-  public readonly stem: string;
 
   constructor(file: TFile) {
     this.originalText = file.basename;
     this.replaceText = `[[${file.basename}]]`;
-    this.stem = stemmer(this.originalText);
   }
 }

--- a/src/indexing/indexer.ts
+++ b/src/indexing/indexer.ts
@@ -17,7 +17,7 @@ export class Indexer {
     return this.indexAllTags(allFiles)
       .concat(allFiles.map((file) => this.indexFile(file)).flat())
       .reduce((acc: Index, index) => {
-        return { ...acc, [index.stem]: index };
+        return { ...acc, [index.originalText.toLowerCase()]: index };
       }, {});
   }
 

--- a/src/utils/stemmer.ts
+++ b/src/utils/stemmer.ts
@@ -1,6 +1,0 @@
-import lunr from 'lunr';
-
-export const stemmer = (str: string): string => {
-  const token = lunr.stemmer(new lunr.Token(str, {}));
-  return token.toString().toLowerCase();
-};


### PR DESCRIPTION
Pivoting searching solution. Away from Lunr.js (which just could not handle exact word search). Instead using a "dictionary-matching" algorithm, [Aho-Corasick][1], which is more appropriate for Sidekick's use case.

This change loses stemming functionality. Something to consider bringing in later if users ask for it.

[1]: https://en.wikipedia.org/wiki/Aho%E2%80%93Corasick_algorithm