### PR TITLE
Render suggestions in Menu. Support multiple suggestions for a keyword

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "obsidian-sidekick",
   "name": "Sidekick",
   "description": "A companion to identify hidden connections that match your tags and pages",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "minAppVersion": "0.13.8",
   "author": "Hady Osman",
   "authorUrl": "https://hady.geek.nz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-sidekick",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A companion to identify hidden connections that match your tags and pages",
   "main": "src/index.ts",
   "repository": {
@@ -51,7 +51,6 @@
     "lint-staged": "^11.2.4",
     "obsidian": "^0.13.11",
     "prettier": "^2.2.1",
-    "prettier-plugin-svelte": "^2.2.0",
     "rimraf": "^3.0.2",
     "style-loader": "^3.3.1",
     "terser-webpack-plugin": "^5.2.5",
@@ -73,7 +72,6 @@
     "@tanishiking/aho-corasick": "^0.0.1",
     "lodash": "^4.17.21",
     "lokijs": "^1.5.12",
-    "tiny-typed-emitter": "^2.1.0",
-    "tippy.js": "^6.3.7"
+    "tiny-typed-emitter": "^2.1.0"
   }
 }

--- a/src/cmExtension/suggestionsExtension.ts
+++ b/src/cmExtension/suggestionsExtension.ts
@@ -1,15 +1,15 @@
 import {
   Decoration,
-  DecorationSet,
   EditorView,
   ViewPlugin,
   ViewUpdate,
-  PluginValue,
+  type DecorationSet,
+  type PluginValue,
 } from '@codemirror/view';
 import { RangeSetBuilder } from '@codemirror/rangeset';
-import { debounce, Debouncer } from 'obsidian';
+import { debounce, type Debouncer } from 'obsidian';
 
-import Search from '../search';
+import type Search from '../search';
 import { SuggestionsPopup } from '../components/suggestionsPopup';
 
 import './suggestionsExtension.css';

--- a/src/components/suggestionsPopup.ts
+++ b/src/components/suggestionsPopup.ts
@@ -1,36 +1,29 @@
-import tippy from 'tippy.js';
-import 'tippy.js/dist/tippy.css';
+import { App, Menu, MenuItem } from 'obsidian';
 
-import './suggestionsPopup.css';
-
-type SuggestionsPopupProps = {
-  target: HTMLElement;
-  text: string;
-  onClick: () => void;
+type SuggestionsModalProps = {
+  app: App;
+  mouseEvent: MouseEvent;
+  suggestions: string[];
+  onClick: (replaceText: string) => void;
 };
 
-export class SuggestionsPopup {
-  public show(props: SuggestionsPopupProps): void {
-    const { text, onClick, target } = props;
+const item = (icon, title, click) => {
+  return (item: MenuItem) => item.setIcon(icon).setTitle(title).onClick(click);
+};
 
-    const button = document.createElement('button');
-    button.innerText = text;
-    button.title = 'Suggestion';
-    button.onclick = () => {
-      onClick();
-      tippyInstance.hide();
-    };
+export const showSuggestionsModal = (props: SuggestionsModalProps): void => {
+  const { app, mouseEvent, suggestions, onClick } = props;
 
-    const tippyInstance = tippy(target, {
-      content: button,
-      trigger: 'click',
-      theme: 'obsidian',
-      interactive: true,
-      appendTo: document.body,
-      allowHTML: true,
-      onHidden: () => {
-        tippyInstance.destroy();
-      },
-    });
-  }
-}
+  const menu = new Menu(app);
+
+  suggestions.forEach((replaceText) => {
+    menu.addItem(
+      item('pencil', `Replace with ${replaceText}`, () => {
+        onClick(replaceText);
+      })
+    );
+  });
+
+  menu.addSeparator();
+  menu.showAtMouseEvent(mouseEvent);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,8 +23,13 @@ export default class TagsAutosuggestPlugin extends Plugin {
     pluginHelper.onFileMetadataChanged((file) => indexer.replaceFileIndices(file));
 
     // Re/load highlighting extension after any changes to index
-    indexer.on('indexRebuilt', () => this.updateEditorExtension(suggestionsExtension(search)));
-    indexer.on('indexUpdated', () => this.updateEditorExtension(suggestionsExtension(search)));
+    indexer.on('indexRebuilt', () =>
+      this.updateEditorExtension(suggestionsExtension(search, this.app))
+    );
+
+    indexer.on('indexUpdated', () =>
+      this.updateEditorExtension(suggestionsExtension(search, this.app))
+    );
 
     // Build search index on startup (very expensive process)
     pluginHelper.onLayoutReady(() => indexer.buildIndex());

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { Plugin } from 'obsidian';
-import { Extension } from '@codemirror/state';
+import type { Extension } from '@codemirror/state';
 
 import Search from './search';
 import { PluginHelper } from './plugin-helper';

--- a/src/indexing/indexer.ts
+++ b/src/indexing/indexer.ts
@@ -1,8 +1,8 @@
 import lokijs from 'lokijs';
 import { TypedEmitter } from 'tiny-typed-emitter';
-import { TFile } from 'obsidian';
+import type { TFile } from 'obsidian';
 
-import { PluginHelper } from '../plugin-helper';
+import type { PluginHelper } from '../plugin-helper';
 
 type Document = {
   fileCreationTime: number;

--- a/src/search/index.ts
+++ b/src/search/index.ts
@@ -1,6 +1,6 @@
 import { Trie, Emit } from '@tanishiking/aho-corasick';
 
-import { Indexer } from '../indexing/indexer';
+import type { Indexer } from '../indexing/indexer';
 
 type SearchResult = {
   start: number;

--- a/src/utils/getAliases.spec.ts
+++ b/src/utils/getAliases.spec.ts
@@ -1,4 +1,4 @@
-import { CachedMetadata, FrontMatterCache } from 'obsidian';
+import type { CachedMetadata, FrontMatterCache } from 'obsidian';
 
 import { getAliases } from './getAliases';
 

--- a/src/utils/getAliases.ts
+++ b/src/utils/getAliases.ts
@@ -1,4 +1,4 @@
-import { CachedMetadata } from 'obsidian';
+import type { CachedMetadata } from 'obsidian';
 
 export const getAliases = (metadata: CachedMetadata): string[] => {
   const frontmatterAliases = metadata?.frontmatter?.['aliases'];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,17 @@
 {
-  "extends": "@tsconfig/svelte/tsconfig.json",
-
   "include": ["src/**/*", "tests/**/*", "webpack.config.ts"],
   "exclude": ["node_modules/*"],
   "compilerOptions": {
-    "target": "es6",
-    "types": ["node", "svelte", "jest"],
+    "target": "es5",
+    "types": ["node", "jest"],
     "baseUrl": ".",
     "paths": {
       "src": ["src/*", "tests/*"],
       "~/*": ["src/*"]
     },
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "downlevelIteration": true
   },
   // Fixes errors when changing `module` to ES in the above compiler options
   // See: https://github.com/webpack/webpack-cli/issues/2458#issuecomment-846635277

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,17 @@
 {
+  "extends": "@tsconfig/svelte/tsconfig.json",
+
   "include": ["src/**/*", "tests/**/*", "webpack.config.ts"],
   "exclude": ["node_modules/*"],
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "types": ["node", "svelte", "jest"],
     "baseUrl": ".",
     "paths": {
       "src": ["src/*", "tests/*"],
       "~/*": ["src/*"]
     },
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "downlevelIteration": true
+    "resolveJsonModule": true
   },
   // Fixes errors when changing `module` to ES in the above compiler options
   // See: https://github.com/webpack/webpack-cli/issues/2458#issuecomment-846635277

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import pack from './package.json';
 import CopyPlugin from 'copy-webpack-plugin';
 import TerserPlugin from 'terser-webpack-plugin';
-import { Configuration, DefinePlugin } from 'webpack';
+import { type Configuration, DefinePlugin } from 'webpack';
 
 const isProduction = process.env.NODE_ENV === 'production';
 

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -62,11 +62,10 @@ const config: Configuration = {
   ],
   resolve: {
     alias: {
-      svelte: path.resolve('node_modules', 'svelte'),
       '~': path.resolve(__dirname, 'src'),
     },
-    extensions: ['.ts', '.tsx', '.js', '.svelte'],
-    mainFields: ['svelte', 'browser', 'module', 'main'],
+    extensions: ['.ts', '.tsx', '.js'],
+    mainFields: ['browser', 'module', 'main'],
   },
   externals: {
     obsidian: 'commonjs2 obsidian',


### PR DESCRIPTION
This PR brings support for showing suggestions for keywords that could result in multiple suggestions (e.g. duplicate aliases).

As part of this change, the suggestion modal has been changed to a simple Menu to make it easier to scroll through multiple suggestions.