### PR TITLE
Fix suggestion menu display. Made highlighting faster 

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "obsidian-sidekick",
   "name": "Sidekick",
   "description": "A companion to identify hidden connections that match your tags and pages",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "minAppVersion": "0.13.8",
   "author": "Hady Osman",
   "authorUrl": "https://hady.geek.nz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-sidekick",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "A companion to identify hidden connections that match your tags and pages",
   "main": "src/index.ts",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prettier": "prettier --write '**/*.{ts,js,css,html}'",
     "lint": "tsc --noemit && eslint . --ext .ts",
     "clean": "rimraf dist main.js*",
-    "test": "jest --passWithNoTests",
+    "test": "jest --passWithNoTests --verbose",
     "test-watch": "jest --watch",
     "dev": "NODE_ENV=development webpack && cp ./dist/main.js* .",
     "build": "NODE_ENV=production webpack",
@@ -70,8 +70,10 @@
   },
   "dependencies": {
     "@tanishiking/aho-corasick": "^0.0.1",
+    "@types/natural": "^5.1.0",
     "lodash": "^4.17.21",
     "lokijs": "^1.5.12",
+    "natural": "^5.1.13",
     "tiny-typed-emitter": "^2.1.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,6 @@ export default class TagsAutosuggestPlugin extends Plugin {
 
     const pluginHelper = new PluginHelper(this);
     const indexer = new Indexer(pluginHelper);
-    const search = new Search(indexer);
 
     this.registerEditorExtension(this.editorExtension);
 
@@ -23,13 +22,15 @@ export default class TagsAutosuggestPlugin extends Plugin {
     pluginHelper.onFileMetadataChanged((file) => indexer.replaceFileIndices(file));
 
     // Re/load highlighting extension after any changes to index
-    indexer.on('indexRebuilt', () =>
-      this.updateEditorExtension(suggestionsExtension(search, this.app))
-    );
+    indexer.on('indexRebuilt', () => {
+      const search = new Search(indexer);
+      this.updateEditorExtension(suggestionsExtension(search, this.app));
+    });
 
-    indexer.on('indexUpdated', () =>
-      this.updateEditorExtension(suggestionsExtension(search, this.app))
-    );
+    indexer.on('indexUpdated', () => {
+      const search = new Search(indexer);
+      this.updateEditorExtension(suggestionsExtension(search, this.app));
+    });
 
     // Build search index on startup (very expensive process)
     pluginHelper.onLayoutReady(() => indexer.buildIndex());

--- a/src/indexing/indexer.ts
+++ b/src/indexing/indexer.ts
@@ -2,11 +2,12 @@ import lokijs from 'lokijs';
 import { TypedEmitter } from 'tiny-typed-emitter';
 import type { TFile } from 'obsidian';
 
+import { tokenize } from './utils';
 import type { PluginHelper } from '../plugin-helper';
 
 type Document = {
   fileCreationTime: number;
-  type: 'tag' | 'alias' | 'page';
+  type: 'tag' | 'alias' | 'page' | 'page-token';
   keyword: string;
   replaceText: string;
 };
@@ -63,6 +64,15 @@ export class Indexer extends TypedEmitter<IndexerEvents> {
       type: 'page',
       keyword: file.basename.toLowerCase(),
       replaceText: `[[${file.basename}]]`,
+    });
+
+    tokenize(file.basename).forEach((token) => {
+      this.documents.insert({
+        fileCreationTime: file.stat.ctime,
+        type: 'page-token',
+        keyword: token,
+        replaceText: `[[${file.basename}]]`,
+      });
     });
 
     this.pluginHelper.getAliases(file).forEach((alias) => {

--- a/src/indexing/utils.spec.ts
+++ b/src/indexing/utils.spec.ts
@@ -1,0 +1,29 @@
+import { tokenize } from './utils';
+
+describe('tokenize', () => {
+  const dataSet = [
+    {
+      sentence: 'The quick brown fox jumps over the lazy dog.',
+      expected: ['quick', 'brown', 'fox', 'jump', 'lazi', 'dog'],
+    },
+    {
+      sentence: 'GitHub Forks',
+      expected: ['github', 'fork'],
+    },
+    {
+      sentence: 'John    Doe',
+      expected: ['john', 'doe'],
+    },
+    {
+      sentence: 'Approximate Inference',
+      expected: ['approxim', 'infer'],
+    },
+  ];
+
+  dataSet.forEach(({ sentence, expected }) => {
+    it(`Tokenizes and removes stop words ("${sentence}", [${expected}]`, () => {
+      const tokens = tokenize(sentence);
+      expect(tokens).toEqual(expected);
+    });
+  });
+});

--- a/src/indexing/utils.ts
+++ b/src/indexing/utils.ts
@@ -1,0 +1,5 @@
+import natural from 'natural';
+
+export const tokenize = (text: string): string[] => {
+  return natural.PorterStemmer.tokenizeAndStem(text);
+};


### PR DESCRIPTION
This PR makes the following changes:

* Fixed suggestion menu "flickering" and not always showing when a word with suggestion is clicked on 

* Performance improvement - the "trie" that is used for searching is only instantiated once when the editor loads, instead of of running on every search 

* A work in progress implementation of supporting highlighting of individual word is also included, but likely to change 
