### PR TITLE
Hierarchical tags are never highlighted

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "obsidian-sidekick",
   "name": "Sidekick",
   "description": "A companion to identify hidden connections that match your tags and pages",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "minAppVersion": "0.13.8",
   "author": "Hady Osman",
   "authorUrl": "https://hady.geek.nz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-sidekick",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "A companion to identify hidden connections that match your tags and pages",
   "main": "src/index.ts",
   "repository": {

--- a/src/search/index.ts
+++ b/src/search/index.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import { Trie, Emit } from '@tanishiking/aho-corasick';
 
+import { redactText } from './search.utils';
 import type { Indexer } from '../indexing/indexer';
 
 type SearchResult = {
@@ -33,7 +34,7 @@ export default class Search {
   }
 
   public find(text: string): SearchResult[] {
-    const redactedText = this.redactText(text); // Redact text that we don't want to be searched
+    const redactedText = redactText(text); // Redact text that we don't want to be searched
 
     const results = this.trie.parseText(redactedText);
 
@@ -62,13 +63,5 @@ export default class Search {
     }
 
     return exists;
-  }
-
-  private redactText(text: string): string {
-    return text
-      .replace(/```[\s\S]+?```/g, (m) => ' '.repeat(m.length)) // remove code blocks
-      .replace(/^\n*?---[\s\S]+?---/g, (m) => ' '.repeat(m.length)) // remove yaml front matter
-      .replace(/#+([a-zA-Z0-9_]+)/g, (m) => ' '.repeat(m.length)) // remove hashtags
-      .replace(/\[(.*?)\]+/g, (m) => ' '.repeat(m.length)); // remove links
   }
 }

--- a/src/search/search.utils.spec.ts
+++ b/src/search/search.utils.spec.ts
@@ -1,0 +1,81 @@
+import { redactText } from './search.utils';
+
+describe('redactText', () => {
+  it('Hashtags are redacted', () => {
+    const sentence = 'I love playing #football';
+    const expected = 'I love playing          ';
+
+    const actual = redactText(sentence);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('Hierarchial hashtags are redacted', () => {
+    const sentence = 'I love playing #sport/football';
+    const expected = 'I love playing                ';
+
+    const actual = redactText(sentence);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('Links are redacted', () => {
+    const sentence = 'I love [[sleeping]] and [[https://aoe.com|gaming]]';
+    const expected = 'I love              and                           ';
+
+    const actual = redactText(sentence);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('Code blocks are redacted', () => {
+    const sentence = '```cs\
+code block\
+```';
+    const expected = '     \
+          \
+   ';
+
+    const actual = redactText(sentence);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('Frontmatter is redacted', () => {
+    const sentence = '---\
+tags: [aoe, aoe2]\
+---\
+# Heading 1\
+```';
+    const expected = '   \
+                 \
+   \
+# Heading 1\
+```';
+
+    const actual = redactText(sentence);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('Frontmatter with preceding empty lines is redacted', () => {
+    const sentence = '\
+\
+---\
+tags: [aoe, aoe2]\
+---\
+# Heading 1\
+```';
+    const expected = '\
+\
+   \
+                 \
+   \
+# Heading 1\
+```';
+
+    const actual = redactText(sentence);
+
+    expect(actual).toEqual(expected);
+  });
+});

--- a/src/search/search.utils.ts
+++ b/src/search/search.utils.ts
@@ -1,0 +1,7 @@
+export const redactText = (text: string): string => {
+  return text
+    .replace(/```[\s\S]+?```/g, (m) => ' '.repeat(m.length)) // remove code blocks
+    .replace(/^\n*?---[\s\S]+?---/g, (m) => ' '.repeat(m.length)) // remove yaml front matter
+    .replace(/#+([a-zA-Z0-9_/]+)/g, (m) => ' '.repeat(m.length)) // remove hashtags
+    .replace(/\[(.*?)\]+/g, (m) => ' '.repeat(m.length)); // remove links
+};


### PR DESCRIPTION
Fixed redacting to ensure that hierarchical tags (many levels) are always redacted so they don't appear in any search.

As part of this changed moved the redact method out and added tests for all its supported use cases