### PR TITLE
Suggestions always exclude any matches related to active file

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "obsidian-sidekick",
   "name": "Sidekick",
   "description": "A companion to identify hidden connections that match your tags and pages",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "minAppVersion": "0.13.8",
   "author": "Hady Osman",
   "authorUrl": "https://hady.geek.nz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-sidekick",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "A companion to identify hidden connections that match your tags and pages",
   "main": "src/index.ts",
   "repository": {

--- a/src/indexing/indexer.ts
+++ b/src/indexing/indexer.ts
@@ -37,18 +37,20 @@ export class Indexer extends TypedEmitter<IndexerEvents> {
   }
 
   public getKeywords(): string[] {
-    // Exclude any keywords associated with active file as we don't want recursive highlighting
-    const exclusionFile = this.pluginHelper.activeFile;
-
     const keywords = this.documents
-      .where((doc) => doc.fileCreationTime !== exclusionFile.stat.ctime)
+      .find({
+        fileCreationTime: { $ne: this.pluginHelper.activeFile.stat.ctime }, // Always exclude indices related to active file
+      })
       .map((doc) => doc.keyword);
 
     return _.uniq(keywords);
   }
 
   public getDocumentsByKeyword(keyword: string): Document[] {
-    return this.documents.find({ keyword: keyword });
+    return this.documents.find({
+      keyword,
+      fileCreationTime: { $ne: this.pluginHelper.activeFile.stat.ctime }, // Always exclude indices related to active file
+    });
   }
 
   public buildIndex(): void {


### PR DESCRIPTION
Whilst Sidekick didn't use any indices for search related to the current active file, it didn't apply this restriction when looking up suggestions. 

This lead to a bug where suggestions still showed results related to the current file if the same keyword matches for more than one note.